### PR TITLE
Progress Fix and Test

### DIFF
--- a/Source/Operation.swift
+++ b/Source/Operation.swift
@@ -561,8 +561,8 @@ class DelegateManager: NSObject, NSURLSessionDataDelegate {
     //handle progress
     func progressHandler(response: Response, expectedLength: Int64, currentLength: Int64) {
         guard let handler = response.progressHandler else { return }
-        let slice = 1/expectedLength
-        handler(Float(slice*currentLength))
+        let slice = Float(1.0)/Float(expectedLength)
+        handler(slice*Float(currentLength))
     }
     
     /**

--- a/Tests/SwiftHTTPTests.swift
+++ b/Tests/SwiftHTTPTests.swift
@@ -38,7 +38,35 @@ class SwiftHTTPTests: XCTestCase {
         }
         waitForExpectationsWithTimeout(30, handler: nil)
     }
-    
+	
+	func testGetProgress() {
+		let expectation1 = expectationWithDescription("testGetProgressFinished")
+		let expectation2 = expectationWithDescription("testGetProgressIncremented")
+
+		do {
+			let opt = try HTTP.GET("http://photojournal.jpl.nasa.gov/tiff/PIA19330.tif", parameters: nil)
+			var alreadyCheckedProgressIncremented: Bool = false
+			opt.progress = { progress in
+				if progress > 0 && !alreadyCheckedProgressIncremented {
+					alreadyCheckedProgressIncremented = true
+					XCTAssert(true, "Pass")
+					expectation2.fulfill()
+				}
+			}
+			opt.start { response in
+				if response.error != nil {
+					XCTAssert(false, "Failure")
+				}
+				XCTAssert(true, "Pass")
+				expectation1.fulfill()
+			}
+		} catch {
+			XCTAssert(false, "Failure")
+		}
+
+		waitForExpectationsWithTimeout(30, handler: nil)
+	}
+	
     func testOperationDependencies() {
         let expectation1 = expectationWithDescription("testOperationDependencies1")
         let expectation2 = expectationWithDescription("testOperationDependencies2")


### PR DESCRIPTION
Conversions between integer and floating-point numeric types must be
made explicit - Integer divided by Integer produces Integer - Converted
to Floats to fix, Simple Test Included